### PR TITLE
docs(README.md): fix 'used by' badge

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/dgraph-io/badger/v4.svg)](https://pkg.go.dev/github.com/dgraph-io/badger/v4)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/badger/v4)](https://goreportcard.com/report/github.com/dgraph-io/badger/v4)
-[![Sourcegraph](https://sourcegraph.com/github.com/hypermodeinc/badger/-/badge.svg)](https://sourcegraph.com/github.com/hypermodeinc/badger?badge)
+[![Network Dependents](https://dependents.info/hypermodeinc/badger/badge?logo=ripple&label=used%20by)](https://dependents.info/hypermodeinc/badger)
 [![ci-badger-tests](https://github.com/hypermodeinc/badger/actions/workflows/ci-badger-tests.yml/badge.svg)](https://github.com/hypermodeinc/badger/actions/workflows/ci-badger-tests.yml)
 [![ci-badger-bank-tests](https://github.com/hypermodeinc/badger/actions/workflows/ci-badger-bank-tests.yml/badge.svg)](https://github.com/hypermodeinc/badger/actions/workflows/ci-badger-bank-tests.yml)
 [![ci-badger-bank-tests-nightly](https://github.com/hypermodeinc/badger/actions/workflows/ci-badger-bank-tests-nightly.yml/badge.svg)](https://github.com/hypermodeinc/badger/actions/workflows/ci-badger-bank-tests-nightly.yml)
@@ -36,7 +36,6 @@ Please consult the [Changelog] for more detailed information on releases.
   - [Getting Started](#getting-started)
     - [Installing](#installing)
       - [Installing Badger Command Line Tool](#installing-badger-command-line-tool)
-      - [Choosing a version](#choosing-a-version)
   - [Badger Documentation](#badger-documentation)
   - [Resources](#resources)
     - [Blog Posts](#blog-posts)
@@ -248,6 +247,8 @@ Below is a list of known projects that use Badger:
   the Fortuna smart contract on the Cardano blockchain
 - [cDNSd](https://github.com/blinklabs-io/cdnsd) - A Cardano blockchain backed DNS server daemon
 - [Dingo](https://github.com/blinklabs-io/dingo) - A Cardano blockchain data node
+- [dependents.info](https://github.com/gouravkhunger/dependents.info) - generate images of github
+  network dependents to showcase in your project's readme
 
 If you are using Badger in a project please send a pull request to add it to the list.
 


### PR DESCRIPTION
**Description**

Thank you for this awesome tool!

I've used it on my latest [open source](https://github.com/gouravkhunger/dependents.info) project [dependents.info](https://dependents.info) which aims to easily showcase repositories that depend on a particular project - by generating shields.io style badges and "used by" images. I intend to maintain the service for long and BadgerDB has been doing really well in storing the generated SVGs.

To give back to BadgerDB, this PR updates the existing "used by" badge on the README - which currently shows 0 users for some reason - to github [network dependents](https://github.com/hypermodeinc/badger/network/dependents) based shields.io style badge.

It also creates an image preview of the users for the readme. Here's how both would look for this repository:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/8d3a43d0-2778-4465-9b9b-54fe0ee92e52" />

The badge as added in this PR is customized as shown below to match close to the style of the existing badge:

<img width="150" alt="image" src="https://github.com/user-attachments/assets/0167d221-c8e3-4c67-80a8-4ec15a316e82" />
<br /><br />

I have not included the full image in the readme yet, but I can update the PR if the maintainers think it'd be a nice addition. Thank you!

**Checklist**

N/A
